### PR TITLE
Remove fails_with :llvm

### DIFF
--- a/Formula/python26.rb
+++ b/Formula/python26.rb
@@ -69,19 +69,6 @@ class Python26 < Formula
     HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"
   end
 
-  fails_with :llvm do
-    build 2336
-    cause <<-EOS.undent
-      Could not find platform dependent libraries <exec_prefix>
-      Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
-      python.exe(14122) malloc: *** mmap(size=7310873954244194304) failed (error code=12)
-      *** error: can't allocate region
-      *** set a breakpoint in malloc_error_break to debug
-      Could not import runpy module
-      make: *** [pybuilddir.txt] Segmentation fault: 11
-    EOS
-  end
-
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
   def pour_bottle?

--- a/Formula/python31.rb
+++ b/Formula/python31.rb
@@ -60,19 +60,6 @@ class Python31 < Formula
     HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"
   end
 
-  fails_with :llvm do
-    build 2336
-    cause <<-EOS.undent
-      Could not find platform dependent libraries <exec_prefix>
-      Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
-      python.exe(14122) malloc: *** mmap(size=7310873954244194304) failed (error code=12)
-      *** error: can't allocate region
-      *** set a breakpoint in malloc_error_break to debug
-      Could not import runpy module
-      make: *** [pybuilddir.txt] Segmentation fault: 11
-    EOS
-  end
-
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
   def pour_bottle?

--- a/Formula/python32.rb
+++ b/Formula/python32.rb
@@ -59,19 +59,6 @@ class Python32 < Formula
     HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"
   end
 
-  fails_with :llvm do
-    build 2336
-    cause <<-EOS.undent
-      Could not find platform dependent libraries <exec_prefix>
-      Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
-      python.exe(14122) malloc: *** mmap(size=7310873954244194304) failed (error code=12)
-      *** error: can't allocate region
-      *** set a breakpoint in malloc_error_break to debug
-      Could not import runpy module
-      make: *** [pybuilddir.txt] Segmentation fault: 11
-    EOS
-  end
-
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
   def pour_bottle?

--- a/Formula/python33.rb
+++ b/Formula/python33.rb
@@ -58,19 +58,6 @@ class Python33 < Formula
     HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"
   end
 
-  fails_with :llvm do
-    build 2336
-    cause <<-EOS.undent
-      Could not find platform dependent libraries <exec_prefix>
-      Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
-      python.exe(14122) malloc: *** mmap(size=7310873954244194304) failed (error code=12)
-      *** error: can't allocate region
-      *** set a breakpoint in malloc_error_break to debug
-      Could not import runpy module
-      make: *** [pybuilddir.txt] Segmentation fault: 11
-    EOS
-  end
-
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
   def pour_bottle?

--- a/Formula/python34.rb
+++ b/Formula/python34.rb
@@ -58,19 +58,6 @@ class Python34 < Formula
     HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"
   end
 
-  fails_with :llvm do
-    build 2336
-    cause <<-EOS.undent
-      Could not find platform dependent libraries <exec_prefix>
-      Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
-      python.exe(14122) malloc: *** mmap(size=7310873954244194304) failed (error code=12)
-      *** error: can't allocate region
-      *** set a breakpoint in malloc_error_break to debug
-      Could not import runpy module
-      make: *** [pybuilddir.txt] Segmentation fault: 11
-    EOS
-  end
-
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
   def pour_bottle?


### PR DESCRIPTION
I have removed this because this is causing the following warning in homebrew:

```
Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/drolando/homebrew-deadsnakes/Formula/python34.rb:61:in `<class:Python34>'
Please report this to the drolando/deadsnakes tap!
```